### PR TITLE
Set Content-Type header in response

### DIFF
--- a/physical.go
+++ b/physical.go
@@ -74,14 +74,13 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 		Healthy:   healthy,
 		Unhealthy: unhealthy,
 	}
+	w.Header().Set("Content-Type", "application/json")
 	body, err := json.Marshal(hcr)
-
 	if err != nil || len(unhealthy) > 0 {
 		w.WriteHeader(http.StatusInternalServerError)
 	} else {
 		w.WriteHeader(http.StatusOK)
 	}
-
 	w.Write(body)
 }
 


### PR DESCRIPTION
Since we return JSON, we should set `Content-Type=application/json`.

This messes up some monitoring we have, since it receives the default `Content-Type: text/plain; charset=utf-8` currently, and expects only JSON for its health checks.

Tested by building and running sample program before/after change.

# Before

```
curl -v http://localhost:8077/healthcheck
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8077 (#0)
> GET /healthcheck HTTP/1.1
> Host: localhost:8077
> User-Agent: curl/7.52.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Date: Fri, 17 Mar 2017 10:05:54 GMT
< Content-Length: 117
< Content-Type: text/plain; charset=utf-8
<
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
{"healthy":[{"actionable":true,"healthy":true,"name":"Sample Check","type":"SELF","dependent_on":{}}],"unhealthy":[]}
```

# After

```
curl -v http://localhost:8077/healthcheck
*   Trying ::1...
* TCP_NODELAY set
* Connected to localhost (::1) port 8077 (#0)
> GET /healthcheck HTTP/1.1
> Host: localhost:8077
> User-Agent: curl/7.52.1
> Accept: */*
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Date: Fri, 17 Mar 2017 10:13:58 GMT
< Content-Length: 117
<
* Curl_http_done: called premature == 0
* Connection #0 to host localhost left intact
{"healthy":[{"actionable":true,"healthy":true,"name":"Sample Check","type":"SELF","dependent_on":{}}],"unhealthy":[]}
```