### PR TITLE
Run healthchecks concurrently in goroutines

### DIFF
--- a/physical.go
+++ b/physical.go
@@ -3,6 +3,7 @@ package physical
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/gorilla/mux"
 )
@@ -88,9 +89,20 @@ func healthCheckHandler(w http.ResponseWriter, r *http.Request) {
 func performChecks() ([]HealthCheckResponse, []HealthCheckResponse) {
 	healthy := []HealthCheckResponse{}
 	unhealthy := []HealthCheckResponse{}
+	wg := sync.WaitGroup{}
+	checks := make(chan HealthCheckResponse, len(healthChecks))
 
 	for _, hc := range healthChecks {
-		h := hc.fun()
+		wg.Add(1)
+		go func(hc *healthCheck) {
+			defer wg.Done()
+			checks <- hc.fun()
+		}(hc)
+	}
+
+	wg.Wait()
+	close(checks)
+	for h := range checks {
 		if h.Healthy {
 			healthy = append(healthy, h)
 		} else {


### PR DESCRIPTION
This allows overall healthCheckHandler to be as fast as the
slowest healthCheck, as opposed to the sum of the run time of
all individual healthchecks.

The difference can be large if there's several healthchecks which
all take some time individually.